### PR TITLE
add support for Cloudtrail

### DIFF
--- a/log_forwarder/data_retriever.py
+++ b/log_forwarder/data_retriever.py
@@ -41,6 +41,12 @@ class LBAccessLogsRetriever(S3DataRetriever):
         return self.src_key.split('/')[-1].split('.')[1]
 
 
+class CloudtrailLogsRetriever(S3DataRetriever):
+
+    def get_data_id(self):
+        return 'cloudtrail'
+
+
 class CloudwatchDataRetriever(DataRetriever):
 
     def __init__(self, config: Config):
@@ -62,6 +68,8 @@ class DataRetrieverFactory:
 
     @staticmethod
     def get_data_retriever(event, config: Config):
+        if 'Records' in event and 'CloudTrail' in event['Records'][0]['s3']['object']['key']:
+            return CloudtrailLogsRetriever(config)
         if 'Records' in event and event['Records'][0]['s3']['object']['key'].split('/')[1] == 'AWSLogs':
             return LBAccessLogsRetriever(config)
         if 'Records' in event:

--- a/log_forwarder/logfile.py
+++ b/log_forwarder/logfile.py
@@ -50,10 +50,8 @@ class LogFileFactory:
 
     @staticmethod
     def get_log_file(log_type, filepath):
-        if log_type == 's3_access_log':
+        if log_type in ['s3_access_log', 'cloudwatch_log']:
             return PlaintextFile(filepath)
-        if log_type == 'alb_access_log':
+        if log_type in ['alb_access_log', 'cloudtrail_log']:
             return GZipFile(filepath)
-        if log_type == 'cloudwatch_log':
-            return PlaintextFile(filepath)
         return GZipFile(filepath)


### PR DESCRIPTION
Some of the Cloudtrail data is different from everything else that is already in place where a single line is a Json structure with one key (`Records`) which itself contains a list of records. This change splits each such entry out into several entries.