### PR TITLE
Add cloudfront data retriever and improve parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The key of the maps are S3 bucket names for S3 access logs,
 load balancers names for load balancers access logs and log group names for cloudwatch logs. In general, 
 - For Cloudwatch logs, the keys in the destination configuration map are matched against a log group name.
 - For logs delivered to AWS S3, the keys in the destination configuration map are matched against the AWS 
-resource name (e.g. S3 bucket or load balancer names on which access logs is enabled).
+resource name (e.g. S3 bucket name, load balancer name, or Cloudfront distribution ID on which access logs are enabled).
 
 ### Supported Log Type
 
@@ -48,7 +48,5 @@ This function can parse keys and values of the following log types:
 logs are being forwarded)
 - Cloudtrail
 - ALB
-- NLB
-- Classic LB
 - VPC Flow Log (version 2 to 5)
-- CloudFront Standard and Realtime access logs
+- CloudFront Standard access logs

--- a/log_forwarder/config.py
+++ b/log_forwarder/config.py
@@ -35,3 +35,6 @@ class DestinationConfig:
 
     def get_log_type(self, key):
         return self._get_attribute_value(key, 'log_type')
+
+    def get_keys(self):
+        return self.destination_config.keys()

--- a/log_forwarder/forward.py
+++ b/log_forwarder/forward.py
@@ -14,7 +14,7 @@ def forward_logs(event, _):
     dest_config = DestinationConfig()
     config = Config(event)
 
-    for data_retriever in DataRetrieverFactory.get_data_retrievers(config):
+    for data_retriever in DataRetrieverFactory.get_data_retrievers(config, dest_config):
         if data_retriever is None:
             logger.info('Unknown data type from event. Aborting. event=%s', event)
             return

--- a/log_forwarder/parser.py
+++ b/log_forwarder/parser.py
@@ -69,10 +69,18 @@ class CloudFrontRealtimeAccessLogParser(Parser):
 
 class CloudFrontStandardAccessLogParser(Parser):
 
-    REGEX = r'(?P<date_time>[0-9-:\t]+)\t(?P<x_edge_location>[0-9A-Z-]+)\t(?P<sc_bytes>[0-9]+)\t(?P<c_ip>[0-9a-f.:]+)\t(?P<cs_method>[A-Z]+)\t(?P<cs_host>[0-9A-Za-z.]+)\t(?P<cs_uri_stem>[^\t]+)\t(?P<sc_status>[0-9-]+)\t(?P<cs_referer>[^\t]+)\t(?P<cs_user_agent>[^\t]+)\t(?P<cs_uri_query>[^\t]+)\t(?P<cs_cookie>[^\t]+)\t(?P<x_edge_result_type>[^\t]+)\t(?P<x_edge_request_id>[^\t]+)\t(?P<x_host_header>[^\t]+)\t(?P<cs_protocol>[^\t]+)\t(?P<cs_bytes>[^\t]+)\t(?P<time_taken>[^\t]+)\t(?P<x_forwarded_for>[^\t]+)\t(?P<ssl_protocol>[^\t]+)\t(?P<ssl_cipher>[^\t]+)\t(?P<x_edge_response_result_type>[^\t]+)\t(?P<cs_protocol_version>[^\t]+)\t(?P<fle_status>[^\t]+)\t(?P<fle_encrypted_fields>[^\t]+)(\t(?P<c_port>[^\t]+)\t(?P<time_to_first_byte>[^\t]+)\t(?P<x_edge_detailed_result_type>[^\t]+)\t(?P<sc_content_type>[^\t]+)\t(?P<sc_content_len>[^\t]+)\t(?P<sc_range_start>[^\t]+)\t(?P<sc_range_end>[^\t]+))?'
+    REGEX = r'(?P<date>[0-9-]+)\t(?P<time>[0-9:]+)\t(?P<x_edge_location>[0-9A-Z-]+)\t(?P<sc_bytes>[0-9]+)\t(?P<c_ip>[0-9a-f.:]+)\t(?P<cs_method>[A-Z]+)\t(?P<cs_host>[0-9A-Za-z.]+)\t(?P<cs_uri_stem>[^\t]+)\t(?P<sc_status>[0-9-]+)\t(?P<cs_referer>[^\t]+)\t(?P<cs_user_agent>[^\t]+)\t(?P<cs_uri_query>[^\t]+)\t(?P<cs_cookie>[^\t]+)\t(?P<x_edge_result_type>[^\t]+)\t(?P<x_edge_request_id>[^\t]+)\t(?P<x_host_header>[^\t]+)\t(?P<cs_protocol>[^\t]+)\t(?P<cs_bytes>[^\t]+)\t(?P<time_taken>[^\t]+)\t(?P<x_forwarded_for>[^\t]+)\t(?P<ssl_protocol>[^\t]+)\t(?P<ssl_cipher>[^\t]+)\t(?P<x_edge_response_result_type>[^\t]+)\t(?P<cs_protocol_version>[^\t]+)\t(?P<fle_status>[^\t]+)\t(?P<fle_encrypted_fields>[^\t]+)(\t(?P<c_port>[^\t]+)\t(?P<time_to_first_byte>[^\t]+)\t(?P<x_edge_detailed_result_type>[^\t]+)\t(?P<sc_content_type>[^\t]+)\t(?P<sc_content_len>[^\t]+)\t(?P<sc_range_start>[^\t]+)\t(?P<sc_range_end>[^\t]+))?'
 
     def __init__(self, input_file):
         super().__init__(CloudFrontStandardAccessLogParser.REGEX, input_file)
+
+    # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#BasicDistributionFileFormat
+    def get_parsed_lines(self):
+        for line in self.input_file.get_lines():
+            # Cloudfront Standard log files contain headers starting with '#'. This also skips empty lines,
+            # should there be any.
+            if len(line) > 0 and line[0] != '#':
+                yield self.parse(line)
 
 
 class VPCFlowLogParser(Parser):


### PR DESCRIPTION
The format of the path on S3 where cloudfront logs are delivered requires a dedicated DataRetriever. 

Also the current parser did not account for the headers present in these log files.

Finally, this change preserves the format of these logs `date` and `time` parsing.