### PR TITLE
Add support for data already formatted and proxied via Cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ A sample configuration is:
       "dataset": "log-group-logs",
       "collection": "lambdaLogs",
       "log_type": "cloudwatch_log"
+    },
+    "my-clustom-data-in-log-group-name": {
+      "dataset": "log-group-logs",
+      "collection": "MyCustomCollection",
+      "log_type": "cloudwatch_log",
+      "client_type": "FluentD"
     }
   }
 ```
@@ -45,7 +51,7 @@ Notes:
 
 - For logs delivered to AWS S3, only data matching an entry in the configuration is forwarded.
 - For logs delivered to Cloudwatch, `log_type` should be set to `cloudwatch_log`.
-- For logs delivered to AWS S3, `log_type` is a mandatory field. `dataset` and `collection` are optional. Data will be 
+- For logs delivered to AWS S3, `log_type` is a mandatory field. `dataset` and `collection` are optional. Data will be
 forwarded to default Collection and Dataset if `dataset` and `collection` are not set. The possible log_type values are:
   - `bedrock_s3` for Bedrock logs delivered to S3. Note that some Bedrock model invocation logs may be delivered to Cloudwatch too.
   - `vpc_flow_log`
@@ -56,6 +62,9 @@ forwarded to default Collection and Dataset if `dataset` and `collection` are no
   - `clb_access_log`
   - `cf_realtime_access_log`
   - `cf_standard_access_log`
+- `client_type` is optional and should only be set when forwarding log data that is already in a format that should not 
+be altered by this integration, e.g. the data is already in the `FluentD` format. Currently, the only values supported 
+are `FluentD` and `LogStash`.
 - For Cloudwatch logs, entries in the configuration map are optional. If not set, the bronto destination 
 (i.e. `dataset` and `collection`) is so that:  
   - the collection is defined with the `cloudwatch_default_collection` environment variable or the default Bronto 
@@ -73,3 +82,4 @@ logs are being forwarded)
 - ALB
 - VPC Flow Log (version 2 to 5)
 - CloudFront Standard access logs
+- Custom (data is forwarded to Bronto without any modification. Set `client_type` for this case).

--- a/log_forwarder/config.py
+++ b/log_forwarder/config.py
@@ -101,3 +101,6 @@ class DestinationConfig:
 
     def get_cloudwatch_default_collection(self):
         return self.cloudwatch_default_collection
+
+    def get_client_type(self, key):
+        return self._get_attribute_value(key, 'client_type')

--- a/log_forwarder/forward.py
+++ b/log_forwarder/forward.py
@@ -35,6 +35,7 @@ def process(event):
         dataset = destination_provider.get_dataset(data_id)
         collection = destination_provider.get_collection(data_id)
         log_type = dest_config.get_log_type(data_id)
+        client_type = dest_config.get_client_type(data_id)
         logger.info('Destination information retrieved. dataset=%s, collection=%s, log_type=%s', dataset,
                     collection, log_type)
         if log_type is None:
@@ -46,8 +47,10 @@ def process(event):
         logger.info('Parser selected. parser=%s', type(parser).__name__)
         attributes = config.get_resource_attributes()
         attributes.update(data_retriever.get_log_attributes_from_payload())
-        bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection)
-        batch = Batch()
+        bronto_client = BrontoClient(dest_config.bronto_api_key, dest_config.bronto_endpoint, dataset, collection,
+            client_type)
+        no_formatting = client_type is not None
+        batch = Batch(no_formatting)
         for line in parser.get_parsed_lines():
             batch.add(line)
             if batch.get_batch_size() > dest_config.max_batch_size:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -19,3 +19,11 @@ def test_get_formatted_batch():
     expected = {'log': entry}
     expected.update(attributes)
     assert json.loads(batch.get_formatted_data(attributes)) == expected
+
+def test_get_formatted_batch_with_no_formatting():
+    batch = Batch(no_formatting=True)
+    entry = "an entry"
+    batch.add(entry)
+    attributes = {'key': 'value'}
+    assert batch.get_formatted_data(attributes) == entry
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ def test_destination_config(monkeypatch):
     assert dest_config.get_dataset(key) == raw_config[key]['dataset']
     assert dest_config.get_collection(key) == raw_config[key]['collection']
     assert dest_config.get_keys() == [key]
+    assert dest_config.get_client_type(key) is None
 
 def test_legacy_destination_config(monkeypatch):
     key = 'some_id'
@@ -69,3 +70,11 @@ def test_attributes_config_malformed(monkeypatch):
 def test_get_keys_no_config():
     dest_config = DestinationConfig()
     assert dest_config.get_keys() == []
+
+def test_destination_config_client_type(monkeypatch):
+    key = 'some_id'
+    raw_config = {key: {'dataset': 'my_dataset', 'collection': 'my_collection', 'log_type': 'my_log_type',
+        'client_type': 'my_client_type'}}
+    monkeypatch.setenv('destination_config', base64.b64encode(json.dumps(raw_config).encode()).decode())
+    dest_config = DestinationConfig()
+    assert dest_config.get_client_type(key) == raw_config[key]['client_type']


### PR DESCRIPTION
This AWS integration sends data in a format that allows for metadata to be added. In some cases, data may be sent to cloudwatch or s3 as a proxying mechanism and already be in a format that contains metadata. In that case, no formatting is required to be performed and the data can be sent as-is. However, the Bronto backend needs to be made aware of the format being used as it is no longer the one of the integration: this is achieved via the `x-bronto-client` header.