### PR TITLE
Do not report aws_log_type tag if missing from destination config

### DIFF
--- a/log_forwarder/data_retriever.py
+++ b/log_forwarder/data_retriever.py
@@ -16,7 +16,7 @@ class DataRetriever:
     def get_name(self):
         raise NotImplementedError()
 
-    def get_collection_type(self):
+    def get_source_type(self):
         raise NotImplementedError()
 
     def get_data(self):
@@ -37,7 +37,7 @@ class S3DataRetriever(DataRetriever):
         self.s3_client = S3Client(config.filepath)
         logger.debug('type=%s, bucket=%s, s3_key=%s', self.__class__, self.src_bucket_name, self.src_key)
 
-    def get_collection_type(self):
+    def get_source_type(self):
         return 's3'
 
     def get_name(self):
@@ -122,7 +122,7 @@ class CloudwatchDataRetriever(DataRetriever):
     def get_name(self):
         return 'Cloudwatch'
 
-    def get_collection_type(self):
+    def get_source_type(self):
         return 'cloudwatch'
 
     def __init__(self, config: Config):

--- a/log_forwarder/destination_provider.py
+++ b/log_forwarder/destination_provider.py
@@ -1,6 +1,5 @@
 from data_retriever import DataRetriever
 from config import DestinationConfig, CLOUDWATCH_LOG_TYPE
-from exceptions import LogTypeMissingException
 
 
 class DestinationProvider:
@@ -9,20 +8,16 @@ class DestinationProvider:
         self._config: DestinationConfig = dest_config
         self._data_retriever: DataRetriever = data_retriever
 
-    def get_type(self, data_id):
-        if (self._config.destination_config is not None and data_id in self._config.get_keys() and
-                self._config.get_log_type(data_id) is not None):
-            return self._config.get_log_type(data_id)
-        if self._data_retriever.get_collection_type() == 'cloudwatch':
+    def get_log_type(self, data_id):
+        if self._data_retriever.get_source_type() == 'cloudwatch':
             return CLOUDWATCH_LOG_TYPE
-        raise LogTypeMissingException('Log type required in configuration. data_type=%s, data_id=%s',
-                                      self._data_retriever.get_collection_type(), data_id)
+        return self._config.get_log_type(data_id)
 
     def get_dataset(self, data_id):
         if (self._config.destination_config is not None and data_id in self._config.get_keys() and
                 self._config.get_dataset(data_id) is not None):
             return self._config.get_dataset(data_id)
-        if self._data_retriever.get_collection_type() == 'cloudwatch':
+        if self._data_retriever.get_source_type() == 'cloudwatch':
             return data_id
         return None
 
@@ -30,12 +25,12 @@ class DestinationProvider:
         if (self._config.destination_config is not None and data_id in self._config.get_keys() and
                 self._config.get_collection(data_id) is not None):
             return self._config.get_collection(data_id)
-        if self._data_retriever.get_collection_type() == 'cloudwatch':
+        if self._data_retriever.get_source_type() == 'cloudwatch':
             return self._config.get_cloudwatch_default_collection()
         return None
 
     def get_dataset_tags(self, data_id):
-        log_type = self.get_type(data_id)
-        tags = {'aws_log_type': log_type if log_type is not None else 'unknown'}
+        log_type = self.get_log_type(data_id)
+        tags = {'aws_log_type': log_type} if log_type is not None else {}
         tags.update(self._config.get_dataset_tags(data_id))
         return tags

--- a/log_forwarder/exceptions.py
+++ b/log_forwarder/exceptions.py
@@ -1,2 +1,0 @@
-class LogTypeMissingException(Exception):
-    pass

--- a/tests/test_destination_provider.py
+++ b/tests/test_destination_provider.py
@@ -1,11 +1,10 @@
 import json
 import base64
 import tempfile
-from exceptions import LogTypeMissingException
 
 from config import DestinationConfig, Config, CLOUDWATCH_LOG_TYPE
-from data_retriever import CloudwatchDataRetriever, DataRetriever, S3DataRetriever, CustomS3Retriever, \
-    DataRetrieverFactory, logger
+from data_retriever import (CloudwatchDataRetriever, DataRetriever, S3DataRetriever, CustomS3Retriever,
+                            DataRetrieverFactory)
 from destination_provider import DestinationProvider
 
 import pytest
@@ -14,7 +13,7 @@ def _get_data(data_retriever, log_group_name):
     data_retriever.log_group_name = log_group_name
 
 
-def test_s3_requires_log_type_in_config():
+def test_s3_no_log_type_in_config():
     bucket_name = 'my_bucket'
     s3_key = 'my_key'
     with tempfile.NamedTemporaryFile() as f:
@@ -23,8 +22,7 @@ def test_s3_requires_log_type_in_config():
         dest_config = DestinationConfig()
         data_retriever = S3DataRetriever(config, bucket_name, s3_key)
         destination_provider = DestinationProvider(dest_config, data_retriever)
-        with pytest.raises(LogTypeMissingException) as _:
-            destination_provider.get_type(data_id)
+        assert destination_provider.get_log_type(data_id) is None
 
 
 def test_s3_custom_path():
@@ -49,10 +47,10 @@ def test_cloudwatch_no_config(monkeypatch):
         data_retriever = CloudwatchDataRetriever(config)
         monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name))
         destination_provider = DestinationProvider(dest_config, data_retriever)
-        assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
         assert destination_provider.get_dataset(log_group_name) == log_group_name
         assert destination_provider.get_collection(log_group_name) is None
-        assert destination_provider.get_dataset_tags(log_group_name) == {'aws_log_type': 'cloudwatch_log'}
+        assert destination_provider.get_log_type(log_group_name) == CLOUDWATCH_LOG_TYPE
+        assert destination_provider.get_dataset_tags(log_group_name) == {'aws_log_type': CLOUDWATCH_LOG_TYPE}
 
 
 def test_cloudwatch_default_collection(monkeypatch):
@@ -80,7 +78,6 @@ def test_cloudwatch_config_takes_precedence(monkeypatch):
         # mock _get_data in order to associate log group name to the data retriever
         monkeypatch.setattr(DataRetriever, 'get_data', lambda: _get_data(data_retriever, log_group_name_from_config))
         destination_provider = DestinationProvider(dest_config, data_retriever)
-        assert destination_provider.get_type(log_group_name) == CLOUDWATCH_LOG_TYPE
         assert destination_provider.get_dataset(log_group_name) == log_group_name_from_config
         assert destination_provider.get_collection(log_group_name) == log_set_from_config
 


### PR DESCRIPTION
- `get_collection_type` is renamed `get_source_type` as the current fct name is misleading with regard to Bronto collections, which it does not relate to.
- dataset tags does not report the `aws_log_type` tag rather than failing for the S3 source type, if log_type is not present in the config.